### PR TITLE
ADD: ``tpl-Fischer344``

### DIFF
--- a/tpl-Fischer344.toml
+++ b/tpl-Fischer344.toml
@@ -1,0 +1,2 @@
+[osf]
+project = "fj5r3"


### PR DESCRIPTION
## MRI-Derived Neuroanatomical Atlas of the Fischer 344 Rat Brain

Identifier: Fischer344
Storage: https://osf.io/fj5r3/files/

### Authors
Goerzen, D, Fowler, C, Devenyi, GA, Germann, J, Madularu, D, Chakravarty, MM, Near, J.

### License
CC-by-nc-sa-4.0 International

### Cohorts
The dataset does not contain cohorts.

### References and links
https://doi.org/10.5281/zenodo.3555555, https://doi.org/10.1038/s41598-020-63965-x