### PR TITLE
ADD: ``tpl-NMT31Sym``

### DIFF
--- a/tpl-NMT31Sym.toml
+++ b/tpl-NMT31Sym.toml
@@ -1,0 +1,2 @@
+[github]
+user = "oesteban"


### PR DESCRIPTION
## The NIMH Macaque Template v2 (NMT v2)

Identifier: NMT31Sym
Datalad: https://github.com/oesteban/tpl-NMT31Sym

### Authors
Jung, B., Taylor, P.A., Seidlitz, J., Sponheim, C., Perkins P., Ungerleider, L.G., Glen, D., Messinger, A..

### License
Public Domain

### Cohorts
The dataset does not contain cohorts.

### References and links
https://doi.org/10.1016/j.neuroimage.2021.117997, https://doi.org/10.1101/2020.09.16.30005, https://doi.org/10.1093/cercor/bhw248