### PR TITLE
ADD: ``tpl-MouseIn``

### DIFF
--- a/tpl-MouseIn.toml
+++ b/tpl-MouseIn.toml
@@ -1,0 +1,2 @@
+[github]
+user = "oesteban"


### PR DESCRIPTION
## In Vivo MP2RAGE Templates of the C57Bl6/J Mouse Brain

Identifier: MouseIn
Datalad: https://github.com/oesteban/tpl-MouseIn

### Authors
Kim, E, MacNicol, E, Cash, D.

### License
CC-by-nc-sa-4.0 International

### Cohorts
The dataset does not contain cohorts.

### References and links
https://osf.io/szyqe/