### PR TITLE
ADD: ``tpl-MNI305``

### DIFF
--- a/tpl-MNI305.toml
+++ b/tpl-MNI305.toml
@@ -1,0 +1,2 @@
+[github]
+user = "oesteban"


### PR DESCRIPTION
## MNI Average Brain (305 MRI) Stereotaxic Registration Model

Identifier: MNI305
Datalad: https://github.com/oesteban/tpl-MNI305

### Authors
Collins DL, Neelin P, Peters TM, Evans AC.

### License
See LICENSE file

### Cohorts
The dataset does not contain cohorts.

### References and links
https://doi.org/10.1097/00004728-199403000-00005, https://doi.org/10.1109/NSSMIC.1993.373602, https://www.mcgill.ca/bic/software/tools-data-analysis/anatomical-mri/atlases/mni-305