### PR TITLE
ADD: ``tpl-MNIColin27``

### DIFF
--- a/tpl-MNIColin27.toml
+++ b/tpl-MNIColin27.toml
@@ -1,0 +1,2 @@
+[github]
+user = "oesteban"


### PR DESCRIPTION
## Colin 27 Average Brain, Stereotaxic Registration Model

Identifier: MNIColin27
Datalad: https://github.com/oesteban/tpl-MNIColin27

### Authors
Holmes CJ, Hoge R, Collins DL, Woods R, Toga AW, Evans AC.

### License
See LICENSE file

### Cohorts
The dataset does not contain cohorts.

### References and links
https://doi.org/10.1097/00004728-199803000-00032, https://www.bic.mni.mcgill.ca/ServicesAtlases/Colin27