### PR TITLE
ADD: ``tpl-onavg``

### DIFF
--- a/tpl-onavg.toml
+++ b/tpl-onavg.toml
@@ -1,0 +1,2 @@
+[github]
+user = "feilong"


### PR DESCRIPTION
## onavg (OpenNeuro Average) surface template

Identifier: onavg
Datalad: https://github.com/feilong/tpl-onavg

### Authors
Ma Feilong, Guo Jiahui, M. Ida Gobbini, James V. Haxby.

### License
CC0

### Cohorts
The dataset does not contain cohorts.

### References and links
N/A