### PR TITLE
Fix duplicate tpl-onavg dataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -102,8 +102,6 @@
 	url = https://github.com/templateflow/tpl-MNI152NLin2009bAsym.git
 	datalad-id = f8574711-19f1-4e8c-8d87-2cf96c8da515
 [submodule "tpl-onavg"]
-	url = https://github.com/templateflow/tpl-onavg
-[submodule "tpl-onavg"]
 	path = tpl-onavg
 	url = https://github.com/templateflow/tpl-onavg.git
 	datalad-id = 4fcbb70f-7e3c-4dce-a540-a040ff1aff21


### PR DESCRIPTION
The Canadian Open Neuroscience Platform (CONP) Portal is a web interface that facilitates open science for the neuroscience community by simplifying global access to and sharing of datasets and tools.

One of our dataset uses templateflow as a submodule dependency. Datalad fails to install it because of the multiplicity of the tpl-onavg module. We suspect this duplication is a typo and can be removed, therefore we would like to propose the change.