### PR TITLE
ADD: ``tpl-UNCBCP4DInfant``

### DIFF
--- a/tpl-UNCBCP4DInfant.toml
+++ b/tpl-UNCBCP4DInfant.toml
@@ -1,0 +1,2 @@
+[github]
+user = "gagnonanthony"


### PR DESCRIPTION
## UNC-BCP 4D Infant Brain Volumetric Atlas

Identifier: UNCBCP4DInfant
Datalad: https://github.com/gagnonanthony/tpl-UNCBCP4DInfant

### Authors
Liangjun Chen, Zhengwang Wu, Dan Hu, Ya Wang, Fenqiang Zhao, Tao Zhong, Weili Lin, Li Wang, Gang Li.

### License
GNU General Public License

### Cohorts
The dataset contains 17 cohorts.

### References and links
https://doi.org/10.1016/j.neuroimage.2022.119097, https://doi.org/10.1038/s41596-023-00806-x, https://www.nitrc.org/projects/uncbcp_4d_atlas