### PR TITLE
ADD: ``tpl-SIGMAv2InVivo``

### DIFF
--- a/tpl-SIGMAv2InVivo.toml
+++ b/tpl-SIGMAv2InVivo.toml
@@ -1,0 +1,2 @@
+[github]
+user = "eugenegkim"


### PR DESCRIPTION
## The in vivo SIGMA templates and atlases for the Wistar Rat Brain

Identifier: SIGMAv2InVivo
Datalad: https://github.com/eugenegkim/tpl-SIGMAv2InVivo

### Authors
Barrière DA, Magalhães R, Novais A, Marques P, Selingue E, Geffroy F, Marques F, Cerqueira J, Sousa JC, Boumezbeur F, Bottlaender M, Jay TM, Cachia A, Sousa N, Mériaux S.

### License
CC-BY 4.0 International. See LICENSE file

### Cohorts
The dataset does not contain cohorts.

### References and links
https://zenodo.org/records/7829128, https://doi.org/10.1038/s41467-019-13575-7, https://doi.org/10.1038/s41592-023-02034-3