### PR TITLE
ADD: ``tpl-SIGMAv2ExVivo``

### DIFF
--- a/tpl-SIGMAv2ExVivo.toml
+++ b/tpl-SIGMAv2ExVivo.toml
@@ -1,0 +1,2 @@
+[github]
+user = "eugenegkim"


### PR DESCRIPTION
## The ex vivo SIGMA templates and atlases for the Wistar Rat Brain

Identifier: SIGMAv2ExVivo
Datalad: https://github.com/eugenegkim/tpl-SIGMAv2ExVivo

### Authors
Barrière DA, Magalhães R, Novais A, Marques P, Selingue E, Geffroy F, Marques F, Cerqueira J, Sousa JC, Boumezbeur F, Bottlaender M, Jay TM, Cachia A, Sousa N, Mériaux S.

### License
CC-BY 4.0 International. See LICENSE file

### Cohorts
The dataset contains 2 cohorts.

### References and links
https://zenodo.org/records/7829128, https://doi.org/10.1038/s41467-019-13575-7, https://doi.org/10.1038/s41592-023-02034-3, https://doi.org/10.1038/s41598-017-18896-5